### PR TITLE
Allow default python3 to be installed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     name: shellcheck & shfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
       - uses: luizm/action-sh-checker@v0.8.0
     env:
       SHELLCHECK_OPTS: --external-sources

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,13 @@
 name: Lint
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - master
     paths:
       - "bin/*"
-  push:
+      - ".github/workflows/*"
+  pull_request:
     paths:
       - "bin/*"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ jobs:
     name: shellcheck & shfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: luizm/action-sh-checker@v0.5.0
+      - uses: actions/checkout@4
+      - uses: luizm/action-sh-checker@v0.8.0
     env:
       SHELLCHECK_OPTS: --external-sources
       SHFMT_OPTS: -d -i 2 -ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         if: ${{ matrix.os == 'macos-11'}}
         run: |
           brew install bzip2 lbzip2 lzlib openssl readline sqlite3 tcl-tk xz zlib
+          brew install asdf
           LDFLAGS="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/openssl@1.1/lib" CFLAGS="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I$(xcrun --show-sdk-path)/usr/include -Wno-implicit-function-declaration" asdf install python 3.11.6
 
       - uses: asdf-vm/actions/plugin-test@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
         run: |
           brew install bzip2 lbzip2 lzlib openssl readline sqlite3 tcl-tk xz zlib
           brew install asdf
-          LDFLAGS="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/openssl@1.1/lib" CFLAGS="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I$(xcrun --show-sdk-path)/usr/include -Wno-implicit-function-declaration" asdf install python 3.11.6
+          asdf plugin add python
+          LDFLAGS="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/openssl@1.1/lib" CFLAGS="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I$(xcrun --show-sdk-path)/usr/include -Wno-implicit-function-declaration" asdf plugin install python 3.11.6
 
       - uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     paths:
       - "bin/*"
+      - ".github/workflows/*"
   push:
     paths:
       - "bin/*"
+      - ".github/workflows/*"
   schedule:
     - cron: "0 0 * * *"
 
@@ -18,7 +20,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: asdf-vm/actions/plugin-test@v1
+      - uses: asdf-vm/actions/plugin-test@v3
         with:
           command: az version
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,7 @@ jobs:
       - name: Install extras
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
-          sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.12/
-          sudo rm -rf "/Applications/Python 3.12/"
-          cd /usr/local/bin && ls -l | grep "/Library/Frameworks/Python.framework/Versions/3.12" | awk '{print $9}' | sudo xargs rm
-          brew uninstall python@3.12
-          brew unlink python@3.12
+          brew uninstall --ignore-dependencies python@3.12
           brew link --force python@3.11
           hash -r
           python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
           brew uninstall --ignore-dependencies python@3.12
-          brew link --force python@3.11
+          brew unlink python3.12
+          brew unlink python@3.11 && brew link --force python@3.11
           hash -r
           python3 --version
-          python3 -m pip install distutils
 
       - uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
           which python3
           brew unlink python@3.12
           brew link --force python@3.11
+          rehash
+          python3 --version
+          python3 -m pip install distutils
 
       - uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
           brew uninstall --ignore-dependencies python@3.12
-          brew unlink python3.12
           brew unlink python@3.11 && brew link --force python@3.11
           hash -r
           python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,16 @@
 name: CI
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - "bin/*"
+      - ".github/workflows/*"
   pull_request:
     paths:
       - "bin/*"
       - ".github/workflows/*"
-  push:
-    paths:
-      - "bin/*"
-      - ".github/workflows/*"
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   plugin_test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,15 @@ jobs:
           - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
+    env:
+      PYTHON_TO_NOT_USE: "3.12"
     steps:
       - name: Install extras
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
-          sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.12
-          sudo rm -rf "/Applications/Python 3.12"
-          sudo find /usr/local/bin -lname '../../../Library/Frameworks/Python.framework/Versions/3.12/*' -delete
+          sudo rm -rf "/Library/Frameworks/Python.framework/Versions/${PYTHON_TO_NOT_USE}"
+          sudo rm -rf "/Applications/Python ${PYTHON_TO_NOT_USE}"
+          sudo find /usr/local/bin -lname '../../../Library/Frameworks/Python.framework/Versions/${PYTHON_TO_NOT_USE}/*' -delete
           brew link --force python@3.11
           hash -r
           python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,11 @@ jobs:
       - name: Install extras
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
-          brew unlink python@3.12
           sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.12/
           sudo rm -rf "/Applications/Python 3.12/"
           cd /usr/local/bin && ls -l | grep "/Library/Frameworks/Python.framework/Versions/3.12" | awk '{print $9}' | sudo xargs rm
+          brew uninstall python@3.12
+          brew unlink python@3.12
           brew link --force python@3.11
           hash -r
           python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Install extras
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
-          which python3
           brew unlink python@3.12
+          sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.12/
+          sudo rm -rf "/Applications/Python 3.12/"
+          cd /usr/local/bin && ls -l | grep "/Library/Frameworks/Python.framework/Versions/3.12" | awk '{print $9}' | sudo xargs rm
           brew link --force python@3.11
           hash -r
           python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
           brew uninstall --ignore-dependencies python@3.12
-          brew unlink python@3.11 && brew link --force python@3.11
+          brew link --force python@3.11
           hash -r
           python3 --version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-11
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install extras
-        if: ${{ matrix.os == 'macos-latest'}}
+        if: ${{ matrix.os == 'macos-11'}}
         run: |
           brew install openssl readline sqlite3 xz zlib tcl-tk
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,15 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install extras
-        if: ${{ matrix.os == 'macos-11'}}
+        if: ${{ matrix.os == 'macos-latest'}}
         run: |
-          brew install bzip2 lbzip2 lzlib openssl readline sqlite3 tcl-tk xz zlib
-          brew install asdf
-          asdf plugin add python
-          LDFLAGS="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/openssl@1.1/lib" CFLAGS="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I$(xcrun --show-sdk-path)/usr/include -Wno-implicit-function-declaration" asdf install python 3.11.6
+          which python3
+          brew unlink python@3.12
+          brew link --force python@3.11
 
       - uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           brew install bzip2 lbzip2 lzlib openssl readline sqlite3 tcl-tk xz zlib
           brew install asdf
           asdf plugin add python
-          LDFLAGS="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/openssl@1.1/lib" CFLAGS="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I$(xcrun --show-sdk-path)/usr/include -Wno-implicit-function-declaration" asdf plugin install python 3.11.6
+          LDFLAGS="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/openssl@1.1/lib" CFLAGS="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I$(xcrun --show-sdk-path)/usr/include -Wno-implicit-function-declaration" asdf install python 3.11.6
 
       - uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           which python3
           brew unlink python@3.12
           brew link --force python@3.11
-          rehash
+          hash -r
           python3 --version
           python3 -m pip install distutils
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Install extras
         if: ${{ matrix.os == 'macos-latest'}}
         run: |
-          brew uninstall --ignore-dependencies python@3.12
+          sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.12
+          sudo rm -rf "/Applications/Python 3.12"
+          sudo find /usr/local/bin -lname '../../../Library/Frameworks/Python.framework/Versions/3.12/*' -delete
           brew link --force python@3.11
           hash -r
           python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install extras
         if: ${{ matrix.os == 'macos-11'}}
         run: |
-          brew install openssl readline sqlite3 xz zlib tcl-tk
+          brew install bzip2 lbzip2 lzlib openssl readline sqlite3 tcl-tk xz zlib
+          LDFLAGS="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/openssl@1.1/lib" CFLAGS="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I$(xcrun --show-sdk-path)/usr/include -Wno-implicit-function-declaration" asdf install python 3.11.6
 
       - uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,16 @@ jobs:
     name: asdf plugin test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install extras
+        if: ${{ matrix.os == 'macos-latest'}}
+        run: |
+          brew install openssl readline sqlite3 xz zlib tcl-tk
+
       - uses: asdf-vm/actions/plugin-test@v3
         with:
           command: az version

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 https://github.com/itspngu
+Copyright (c) 2023 https://github.com/boris-ning-usds
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,9 @@
 # asdf-azure-cli
 
-<div align="left">
-  <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />
-  <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/Lint/badge.svg" />
-  <a style="text-decoration:none" href="https://choosealicense.com/licenses/0bsd/">
-    <img src="https://img.shields.io/badge/License-BSD_0--Clause-orange.svg"/>
-  </a>
-  <a style="text-decoration:none" ref="https://asdf-vm.com/">
-    <img src="https://img.shields.io/badge/doc-asdf-blue"/>
-  </a>
-</div>
-<br/>
+![CI](https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg)
+![Lint](https://github.com/boris-ning-usds/asdf-azure-cli/workflows/Lint/badge.svg)
+[![License](https://img.shields.io/badge/License-BSD_0--Clause-orange.svg)](https://choosealicense.com/licenses/0bsd/)
+[![Doc](https://img.shields.io/badge/Doc-asdf-blue)](https://asdf-vm.com/)
 
 Forked and modified from [itspngu](https://github.com/itspngu/asdf-azure-cli) as the project has been archived.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # asdf-azure-cli
 
 <div align="left">
-  <a href="https://asdf-vm.com/" target="_blank">
+  <a href="https://asdf-vm.com/">
     <img src="https://img.shields.io/badge/doc-asdf-blue" />
   </a>
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
-# asdf-azure-cli ![CI](https://github.com/itspngu/asdf-azure-cli/workflows/CI/badge.svg) ![Lint](https://github.com/itspngu/asdf-azure-cli/workflows/Lint/badge.svg)
+# asdf-azure-cli
+
+<div align="left">
+  <a href="https://asdf-vm.com/" target="_blank">
+    <img src="https://img.shields.io/badge/doc-asdf-blue" />
+  </a>
+  <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />
+  <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/Lint/badge.svg" />
+  <a href="https://choosealicense.com/licenses/0bsd/">
+    <img src="https://img.shields.io/badge/License-BSD_0--Clause-orange.svg"/>
+  </a>
+</div>
+<br/>
+
+Forked and modified from [itspngu](https://github.com/itspngu/asdf-azure-cli) as the project has been archived.
 
 [azure-cli](https://github.com/Azure/azure-cli) plugin for the [asdf version manager](https://asdf-vm.com).
-
-## ARCHIVAL NOTICE
-
-I stopped using asdf-vm and archived this repository. If you're using this plugin, please consider forking the repository and having it added to the upstream plugin list at https://github.com/asdf-vm/asdf-plugins.
 
 ## Contents
 
@@ -15,31 +25,31 @@ I stopped using asdf-vm and archived this repository. If you're using this plugi
 ## Plugin Dependencies
 
 - `curl` - for azure-cli downloads from upstream releases
-- `python3` (with `pip` and `venv` modules) - for installing and running the cli
+- `python3` (with `pip` and `venv` modules) - for installing and running the cli where [version 2.54.0 release supports python 3.11](https://github.com/MicrosoftDocs/azure-docs-cli/blob/main/docs-ref-conceptual/release-notes-azure-cli.md#packaging).
 
 ## Install
 
 Plugin:
 
-```shell_session
-$ asdf plugin-add azure-cli https://github.com/itspngu/asdf-azure-cli
+```bash
+asdf plugin-add azure-cli https://github.com/boris-ning-usds/asdf-azure-cli
 ```
 
 azure-cli:
 
-```shell_session
+```bash
 # Show all installable versions
-$ asdf list-all azure-cli
+asdf list-all azure-cli
 
 # Install specific version
-$ asdf install azure-cli latest
+asdf install azure-cli latest
 
 # Set a version globally (in your ~/.tool-versions file)
-$ asdf global azure-cli latest
+asdf global azure-cli latest
 
 # Run azure-cli
-$ az --version
-azure-cli                         2.32.0
+az --version
+> azure-cli 2.54.0
 [...]
 ```
 
@@ -47,6 +57,12 @@ Refer to the [upstream azure-cli repository](https://github.com/Azure/azure-cli)
 
 Check the [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to install & manage versions.
 
+## Uninstall
+
+```bash
+asdf plguin remove azure-cli
+```
+
 ## License
 
-See [LICENSE](LICENSE)
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="left">
   <a href="https://asdf-vm.com/">
-    <img src="https://img.shields.io/badge/doc-asdf-blue" />
+    <img src="https://img.shields.io/badge/doc-asdf-blue"/>
   </a>
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/Lint/badge.svg" />

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 <div align="left">
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/Lint/badge.svg" />
-  <a href="https://choosealicense.com/licenses/0bsd/" style="text-decoration:none">
+  <a style="text-decoration:none" href="https://choosealicense.com/licenses/0bsd/">
     <img src="https://img.shields.io/badge/License-BSD_0--Clause-orange.svg"/>
   </a>
-  <a href="https://asdf-vm.com/" style="text-decoration:none">
+  <a style="text-decoration:none" ref="https://asdf-vm.com/">
     <img src="https://img.shields.io/badge/doc-asdf-blue"/>
   </a>
 </div>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </a>
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/Lint/badge.svg" />
-  <a href="https://choosealicense.com/licenses/0bsd/">
+  <a href="https://choosealicense.com/licenses/0bsd/" style="text-decoration:none">
     <img src="https://img.shields.io/badge/License-BSD_0--Clause-orange.svg"/>
   </a>
 </div>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # asdf-azure-cli
 
 <div align="left">
-  <a href="https://asdf-vm.com/" style="text-decoration:none">
-    <img src="https://img.shields.io/badge/doc-asdf-blue"/>
-  </a>
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/Lint/badge.svg" />
   <a href="https://choosealicense.com/licenses/0bsd/" style="text-decoration:none">
     <img src="https://img.shields.io/badge/License-BSD_0--Clause-orange.svg"/>
+  </a>
+  <a href="https://asdf-vm.com/" style="text-decoration:none">
+    <img src="https://img.shields.io/badge/doc-asdf-blue"/>
   </a>
 </div>
 <br/>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # asdf-azure-cli
 
 <div align="left">
-  <a href="https://asdf-vm.com/">
+  <a href="https://asdf-vm.com/" style="text-decoration:none">
     <img src="https://img.shields.io/badge/doc-asdf-blue"/>
   </a>
   <img src="https://github.com/boris-ning-usds/asdf-azure-cli/workflows/CI/badge.svg" />

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Forked and modified from [itspngu](https://github.com/itspngu/asdf-azure-cli) as the project has been archived.
 
-[azure-cli](https://github.com/Azure/azure-cli) plugin for the [asdf version manager](https://asdf-vm.com).
+This repository is a [azure-cli](https://github.com/Azure/azure-cli) plugin for the [asdf version manager](https://asdf-vm.com). [asdf plugin](https://github.com/asdf-vm/asdf-plugins) is a convenient way to install a large number of command line tools of various versions and to upgrade with a [flat-file](https://asdf-vm.com/manage/configuration.html#tool-versions).
 
 ## Contents
 

--- a/bin/install
+++ b/bin/install
@@ -17,6 +17,17 @@ install() {
     )
   fi
 
+  ## Azure CLI has a hard requirement on python3
+  ##   If the user already has python3, use their version
+  ##   Otherwise, install it for them as best effort
+  SUPPORTED_PYTHON_VERSION="3.11.6"
+  if command -v python3 >/dev/null 2>&1; then
+    echo "python3 already installed"
+  else
+    echo "python3 not installed! Installing python ${SUPPORTED_PYTHON_VERSION}..."
+    asdf install python "${SUPPORTED_PYTHON_VERSION}"
+  fi
+
   mkdir -p "$ASDF_INSTALL_PATH/bin" &&
     python3 -m venv "$ASDF_INSTALL_PATH/bin/venv" &&
     "$ASDF_INSTALL_PATH/bin/venv/bin/python3" -m pip install "$ASDF_DOWNLOAD_PATH/$(get_release_filename)" &&

--- a/bin/install
+++ b/bin/install
@@ -11,10 +11,13 @@ source "$(dirname "$0")/lib"
 install() {
   if [ ! -d "$ASDF_DOWNLOAD_PATH" ]; then
     # shellcheck source=SCRIPTDIR/download
-    source "$(dirname "$0")/download" || (
+    # shellcheck disable=SC2317
+    if source "$(dirname "$0")/download"; then
+      echo "azure-cli $ASDF_INSTALL_VERSION downloaded successfully"
+    else
       echo "Downloading azure-cli $ASDF_INSTALL_VERSION failed" 1>&2
       exit 1
-    )
+    fi
   fi
 
   ## Azure CLI has a hard requirement on python3

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,11 +4,6 @@
 source "$(dirname "$0")/lib"
 
 list_all() {
-  # Somebody, somewhere, makes the asdf-plugin-test action fail if it doesn't find
-  # shellcheck disable=SC2154
-  echo "'Authorization: token $GITHUB_API_TOKEN'" >/dev/null
-  # in this file, so enjoy your auth header, I'll keep the function where it is :P
-
   curl -fsSL "https://pypi.org/simple/$(get_package_name)" |
     sed -En -e "s;.*<a.*>$(get_package_name)-([0-9]+.[0-9]+.[0-9]+)-py3-none-any.whl</a.*;\1;p" |
     sort_versions | paste -sd ' ' -


### PR DESCRIPTION
- Building a more opinionated version of asdf-azure-cli where python3 will be installed via asdf if it doesn't exist, but use the user's python3 if it does exist.
- Updating github action dependencies
- Updating License (not sure if I'm supposed to do that on a forked archived repo), but kept BSD-0 as the license.
- Clarifying the README.